### PR TITLE
March 2020

### DIFF
--- a/Halls_of_Thranduil.cat
+++ b/Halls_of_Thranduil.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="8bcc-84ae-b842-aa89" name="Halls of Thranduil" revision="6" battleScribeVersion="2.03" authorName="Hukoseft" authorContact="hukoseft@gmail.com" library="false" gameSystemId="3e16-9abf-6238-4ed9" gameSystemRevision="39" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="8bcc-84ae-b842-aa89" name="Halls of Thranduil" revision="7" battleScribeVersion="2.03" authorName="Hukoseft" authorContact="hukoseft@gmail.com" library="false" gameSystemId="3e16-9abf-6238-4ed9" gameSystemRevision="39" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="8bcc-84ae-pubN65743" name="Armies of the Hobbit"/>
   </publications>
@@ -279,6 +279,7 @@
               <entryLinks>
                 <entryLink id="bff2-2257-d67e-d424" name="Armour" hidden="false" collective="false" import="true" targetId="991c-46d3-d618-c49e" type="selectionEntry"/>
                 <entryLink id="b5af-a5b6-64a2-9e72" name="Elven-made Daggers" hidden="false" collective="false" import="true" targetId="1a56-de30-3469-9394" type="selectionEntry"/>
+                <entryLink id="7074-bcab-3743-c57b" name="Elven Cloak" hidden="false" collective="false" import="true" targetId="f9b3-aa87-7005-74a4" type="selectionEntry"/>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="9533-8118-b669-909b" name="Options" hidden="false" collective="false" import="true">

--- a/Isengard.cat
+++ b/Isengard.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="a5a6-9c3a-4e49-e794" name="Isengard" revision="23" battleScribeVersion="2.03" authorName="Hukoseft" authorContact="hukoseft@gmail.com" library="false" gameSystemId="3e16-9abf-6238-4ed9" gameSystemRevision="26" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="a5a6-9c3a-4e49-e794" name="Isengard" revision="24" battleScribeVersion="2.03" authorName="Hukoseft" authorContact="hukoseft@gmail.com" library="false" gameSystemId="3e16-9abf-6238-4ed9" gameSystemRevision="26" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="a5a6-9c3a-pubN65614" name="Armies of Lord of the Rings"/>
   </publications>
@@ -2056,11 +2056,6 @@ Hero</characteristic>
             <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c255-a550-bd28-098e" type="equalTo"/>
           </conditions>
         </modifier>
-        <modifier type="remove" field="category" value="0ce2-d79d-fb91-3fa2">
-          <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c255-a550-bd28-098e" type="equalTo"/>
-          </conditions>
-        </modifier>
       </modifiers>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="58f7-606c-623b-3fc4" type="max"/>
@@ -2359,6 +2354,38 @@ Hero</characteristic>
           <conditions>
             <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="a0b1-fb97-208f-e0f7" type="equalTo"/>
           </conditions>
+        </modifier>
+        <modifier type="increment" field="a57d-516e-8363-63c9" value="3.0">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="13fd-94e2-9306-3656" type="equalTo"/>
+              </conditions>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="101e-ea62-7766-406a" type="instanceOf"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="increment" field="a57d-516e-8363-63c9" value="3.0">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c255-a550-bd28-098e" type="equalTo"/>
+              </conditions>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c56-b48e-8137-c1cf" type="instanceOf"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
       </modifiers>
       <constraints>
@@ -3231,6 +3258,22 @@ An enemy model that spends a Fight phase in base contact with a demolition charg
                     <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5daa-6832-f49b-2b35" type="instanceOf"/>
                   </conditions>
                 </modifier>
+                <modifier type="increment" field="b1fd-b247-5768-a1f4" value="3.0">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="13fd-94e2-9306-3656" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="101e-ea62-7766-406a" type="instanceOf"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bbbd-7d86-d47f-17b3" type="min"/>
@@ -3438,6 +3481,27 @@ An enemy model that spends a Fight phase in base contact with a demolition charg
                 <modifier type="decrement" field="309b-d0c9-6408-61c9" value="3.0">
                   <conditions>
                     <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5daa-6832-f49b-2b35" type="instanceOf"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="309b-d0c9-6408-61c9" value="3.0">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="13fd-94e2-9306-3656" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="101e-ea62-7766-406a" type="instanceOf"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+                <modifier type="set" field="name" value="Men">
+                  <conditions>
+                    <condition field="selections" scope="f3d3-277e-3ee3-9341" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="68bd-f205-3e86-fe6f" type="atLeast"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -3831,6 +3895,22 @@ An enemy model that spends a Fight phase in base contact with a demolition charg
                   <conditions>
                     <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5daa-6832-f49b-2b35" type="instanceOf"/>
                   </conditions>
+                </modifier>
+                <modifier type="increment" field="93ab-12b6-be81-d01d" value="3.0">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c255-a550-bd28-098e" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c56-b48e-8137-c1cf" type="instanceOf"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </conditionGroup>
+                  </conditionGroups>
                 </modifier>
               </modifiers>
               <constraints>
@@ -4315,6 +4395,22 @@ An enemy model that spends a Fight phase in base contact with a demolition charg
                     <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5daa-6832-f49b-2b35" type="instanceOf"/>
                   </conditions>
                 </modifier>
+                <modifier type="increment" field="7dd9-967f-9c6e-d3eb" value="3.0">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="13fd-94e2-9306-3656" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="101e-ea62-7766-406a" type="instanceOf"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="928a-8b4e-891c-2712" type="min"/>
@@ -4423,6 +4519,22 @@ Warrior</characteristic>
                   <conditions>
                     <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5daa-6832-f49b-2b35" type="instanceOf"/>
                   </conditions>
+                </modifier>
+                <modifier type="increment" field="1982-3d4f-2bb5-5247" value="3.0">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="13fd-94e2-9306-3656" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="101e-ea62-7766-406a" type="instanceOf"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </conditionGroup>
+                  </conditionGroups>
                 </modifier>
               </modifiers>
               <constraints>
@@ -4551,6 +4663,22 @@ Warrior</characteristic>
                     <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5daa-6832-f49b-2b35" type="instanceOf"/>
                   </conditions>
                 </modifier>
+                <modifier type="increment" field="5ce0-d62d-f4f3-ee5f" value="3.0">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="13fd-94e2-9306-3656" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="101e-ea62-7766-406a" type="instanceOf"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e0c8-a3a6-414c-1f42" type="min"/>
@@ -4630,6 +4758,22 @@ Warrior</characteristic>
                   <conditions>
                     <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5daa-6832-f49b-2b35" type="instanceOf"/>
                   </conditions>
+                </modifier>
+                <modifier type="increment" field="24de-51e9-83b3-5fe9" value="3.0">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c255-a550-bd28-098e" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2c56-b48e-8137-c1cf" type="instanceOf"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </conditionGroup>
+                  </conditionGroups>
                 </modifier>
               </modifiers>
               <constraints>

--- a/Middle-Earth_Strategy_Battle_Game.gst
+++ b/Middle-Earth_Strategy_Battle_Game.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="3e16-9abf-6238-4ed9" name="Middle-Earth Strategy Battle Game" revision="87" battleScribeVersion="2.03" authorName="Hukoseft" authorContact="hukoseft@gmail.com" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
+<gameSystem id="3e16-9abf-6238-4ed9" name="Middle-Earth Strategy Battle Game" revision="89" battleScribeVersion="2.03" authorName="Hukoseft" authorContact="hukoseft@gmail.com" xmlns="http://www.battlescribe.net/schema/gameSystemSchema">
   <publications>
     <publication id="3e16-9abf-pubN102460" name="Middle-Earth Strategy Battle Game Rules Manual"/>
     <publication id="3e16-9abf-pubN103678" name="Armies of Lord of the Rings"/>
@@ -11494,14 +11494,18 @@ Should the driver be killed, another Iron Hills Dwarf on the Chariot immediately
         <modifierGroup>
           <modifiers>
             <modifier type="set" field="a7a6-bb3f-ebe2-404b" value="1.0">
-              <conditions>
-                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1457-d7c4-8533-0bd7" type="equalTo"/>
-              </conditions>
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
                     <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="82da-a349-b99e-d272" type="equalTo"/>
                   </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1457-d7c4-8533-0bd7" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
@@ -19467,9 +19471,7 @@ Hero</characteristic>
         <infoGroup id="feb1-95fa-ca48-b610" name="Special Rules" hidden="false">
           <rules>
             <rule id="c3b9-1640-c146-8b6f" name="The King of Rohan" publicationId="b222-d397-7636-8248" page="129" hidden="false">
-              <description>Helm Hammerhand gains the Mighty Hero special rule.
-Additionally, Helm Hammerhand may declare a Heroic
-Combat each turn without spending Might.</description>
+              <description>Helm Hammerhand gains the Mighty Hero special rule. Additionally, Helm Hammerhand may declare a Heroic Combat each turn without spending Might.</description>
             </rule>
           </rules>
           <infoLinks>

--- a/Numenor.cat
+++ b/Numenor.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="c50a-794b-1517-31f9" name="Númenor" revision="13" battleScribeVersion="2.03" authorName="Hukoseft" authorContact="hukoseft@gmail.com" library="false" gameSystemId="3e16-9abf-6238-4ed9" gameSystemRevision="12" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="c50a-794b-1517-31f9" name="Númenor" revision="14" battleScribeVersion="2.03" authorName="Hukoseft" authorContact="hukoseft@gmail.com" library="false" gameSystemId="3e16-9abf-6238-4ed9" gameSystemRevision="12" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="c50a-794b-pubN65614" name="Armies of Lord of the Rings"/>
   </publications>
@@ -39,6 +39,11 @@
                     <modifier type="increment" field="49e3-08b4-2b5f-a6dd" value="1">
                       <conditions>
                         <condition field="selections" scope="dd59-5a33-c537-516c" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="713d-07e8-7930-c83c" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="b88a-7dd4-569c-d0b1" value="1">
+                      <conditions>
+                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e3dc-8af5-af35-3cba" type="equalTo"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -123,7 +128,12 @@
               <modifiers>
                 <modifier type="increment" field="49e3-08b4-2b5f-a6dd" value="1">
                   <conditions>
-                    <condition field="selections" scope="e676-7232-5d5e-c5ac" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c9b8-81bd-1cd6-8b3e" type="equalTo"/>
+                    <condition field="selections" scope="e676-7232-5d5e-c5ac" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c9b8-81bd-1cd6-8b3e" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="b88a-7dd4-569c-d0b1" value="1">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e3dc-8af5-af35-3cba" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -213,6 +223,11 @@
                 <modifier type="increment" field="49e3-08b4-2b5f-a6dd" value="1">
                   <conditions>
                     <condition field="selections" scope="dfeb-4976-f85f-e278" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c9b8-81bd-1cd6-8b3e" type="equalTo"/>
+                  </conditions>
+                </modifier>
+                <modifier type="increment" field="b88a-7dd4-569c-d0b1" value="1">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e3dc-8af5-af35-3cba" type="equalTo"/>
                   </conditions>
                 </modifier>
               </modifiers>
@@ -405,6 +420,11 @@
                     <modifier type="increment" field="d64a-e776-38fd-3019" value="1">
                       <conditions>
                         <condition field="selections" scope="748a-0297-627b-2b9e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="cb0c-c9a3-15c5-a07b" type="equalTo"/>
+                      </conditions>
+                    </modifier>
+                    <modifier type="increment" field="a0e1-d7a9-598e-1545" value="1">
+                      <conditions>
+                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e3dc-8af5-af35-3cba" type="equalTo"/>
                       </conditions>
                     </modifier>
                   </modifiers>

--- a/Rivendell.cat
+++ b/Rivendell.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="de26-60e8-f5af-59cd" name="Rivendell" revision="23" battleScribeVersion="2.03" authorName="Hukoseft" authorContact="hukoseft@gmail.com" library="false" gameSystemId="3e16-9abf-6238-4ed9" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="de26-60e8-f5af-59cd" name="Rivendell" revision="24" battleScribeVersion="2.03" authorName="Hukoseft" authorContact="hukoseft@gmail.com" library="false" gameSystemId="3e16-9abf-6238-4ed9" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="de26-60e8-pubN65565" name="Armies of Lord of the Rings"/>
   </publications>
@@ -42,12 +42,11 @@
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2e81-d841-b5b1-8a83" type="max"/>
       </constraints>
+      <categoryLinks>
+        <categoryLink id="082a-07d4-078f-453c" name="New CategoryLink" hidden="false" targetId="5daa-6832-f49b-2b35" primary="true"/>
+      </categoryLinks>
       <entryLinks>
-        <entryLink id="8488-e842-c5c9-d47d" name="Warband" hidden="false" collective="false" import="true" targetId="1ecc-20fa-d690-4e88" type="selectionEntry">
-          <modifiers>
-            <modifier type="set" field="1259-51df-340e-70a5" value="15"/>
-          </modifiers>
-        </entryLink>
+        <entryLink id="8488-e842-c5c9-d47d" name="Warband" hidden="false" collective="false" import="true" targetId="1ecc-20fa-d690-4e88" type="selectionEntry"/>
         <entryLink id="7290-09e2-bf28-bcea" name="Glorfindel, Lord of the West" hidden="false" collective="false" import="true" targetId="b890-65d0-511d-dbae" type="selectionEntry"/>
       </entryLinks>
       <costs>
@@ -184,12 +183,11 @@
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="6cdc-8765-0408-10db" type="max"/>
       </constraints>
+      <categoryLinks>
+        <categoryLink id="e436-586a-e102-49f9" name="New CategoryLink" hidden="false" targetId="0ce2-d79d-fb91-3fa2" primary="true"/>
+      </categoryLinks>
       <entryLinks>
-        <entryLink id="3729-95e5-99ac-d7b9" name="Warband" hidden="false" collective="false" import="true" targetId="1ecc-20fa-d690-4e88" type="selectionEntry">
-          <modifiers>
-            <modifier type="set" field="1259-51df-340e-70a5" value="12.0"/>
-          </modifiers>
-        </entryLink>
+        <entryLink id="3729-95e5-99ac-d7b9" name="Warband" hidden="false" collective="false" import="true" targetId="1ecc-20fa-d690-4e88" type="selectionEntry"/>
         <entryLink id="893a-df33-00ec-baa6" name="Lindir of Rivendell" hidden="false" collective="false" import="true" targetId="9abb-7176-3884-d4a8" type="selectionEntry"/>
       </entryLinks>
       <costs>
@@ -686,7 +684,7 @@
                       <conditionGroups>
                         <conditionGroup type="and">
                           <conditions>
-                            <condition field="selections" scope="dd4f-44ed-68db-b147" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5cb3-c11b-0e24-9a90" type="equalTo"/>
+                            <condition field="selections" scope="dd4f-44ed-68db-b147" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5cb3-c11b-0e24-9a90" type="equalTo"/>
                           </conditions>
                         </conditionGroup>
                       </conditionGroups>

--- a/Rohan.cat
+++ b/Rohan.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="88d3-8782-03ed-ae6a" name="Rohan" revision="16" battleScribeVersion="2.03" authorName="Hukoseft" authorContact="hukoseft@gmail.com" library="false" gameSystemId="3e16-9abf-6238-4ed9" gameSystemRevision="16" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="88d3-8782-03ed-ae6a" name="Rohan" revision="18" battleScribeVersion="2.03" authorName="Hukoseft" authorContact="hukoseft@gmail.com" library="false" gameSystemId="3e16-9abf-6238-4ed9" gameSystemRevision="16" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="88d3-8782-pubN66219" name="Armies of Lord of the Rings"/>
   </publications>
@@ -32,6 +32,13 @@
                               <conditions>
                                 <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="6492-fa5a-5a67-6b50" type="equalTo"/>
                               </conditions>
+                              <conditionGroups>
+                                <conditionGroup type="or">
+                                  <conditions>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5341-6e94-fd48-7460" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
                             </conditionGroup>
                           </conditionGroups>
                         </conditionGroup>
@@ -69,6 +76,13 @@
                               <conditions>
                                 <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="6492-fa5a-5a67-6b50" type="equalTo"/>
                               </conditions>
+                              <conditionGroups>
+                                <conditionGroup type="or">
+                                  <conditions>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5341-6e94-fd48-7460" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
                             </conditionGroup>
                           </conditionGroups>
                         </conditionGroup>
@@ -116,6 +130,13 @@
                   <conditions>
                     <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="aa67-eb60-9e79-897c" type="equalTo"/>
                   </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5341-6e94-fd48-7460" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
                 </conditionGroup>
               </conditionGroups>
             </conditionGroup>
@@ -132,6 +153,13 @@
                   <conditions>
                     <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="aa67-eb60-9e79-897c" type="equalTo"/>
                   </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5341-6e94-fd48-7460" type="equalTo"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
                 </conditionGroup>
               </conditionGroups>
             </conditionGroup>
@@ -188,6 +216,13 @@
                               <conditions>
                                 <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="6492-fa5a-5a67-6b50" type="equalTo"/>
                               </conditions>
+                              <conditionGroups>
+                                <conditionGroup type="or">
+                                  <conditions>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5341-6e94-fd48-7460" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
                             </conditionGroup>
                           </conditionGroups>
                         </conditionGroup>
@@ -225,6 +260,13 @@
                               <conditions>
                                 <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="6492-fa5a-5a67-6b50" type="equalTo"/>
                               </conditions>
+                              <conditionGroups>
+                                <conditionGroup type="or">
+                                  <conditions>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5341-6e94-fd48-7460" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
                             </conditionGroup>
                           </conditionGroups>
                         </conditionGroup>
@@ -435,6 +477,13 @@
                               <conditions>
                                 <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="6492-fa5a-5a67-6b50" type="equalTo"/>
                               </conditions>
+                              <conditionGroups>
+                                <conditionGroup type="or">
+                                  <conditions>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5341-6e94-fd48-7460" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
                             </conditionGroup>
                           </conditionGroups>
                         </conditionGroup>
@@ -472,6 +521,13 @@
                               <conditions>
                                 <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="6492-fa5a-5a67-6b50" type="equalTo"/>
                               </conditions>
+                              <conditionGroups>
+                                <conditionGroup type="or">
+                                  <conditions>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5341-6e94-fd48-7460" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
                             </conditionGroup>
                           </conditionGroups>
                         </conditionGroup>
@@ -521,6 +577,13 @@
                       <conditions>
                         <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="b9a7-a628-d572-6b39" type="equalTo"/>
                       </conditions>
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5341-6e94-fd48-7460" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
                     </conditionGroup>
                   </conditionGroups>
                 </conditionGroup>
@@ -544,6 +607,13 @@
                       <conditions>
                         <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="b9a7-a628-d572-6b39" type="equalTo"/>
                       </conditions>
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5341-6e94-fd48-7460" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
                     </conditionGroup>
                   </conditionGroups>
                 </conditionGroup>
@@ -741,6 +811,13 @@
                                       <conditions>
                                         <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="6492-fa5a-5a67-6b50" type="equalTo"/>
                                       </conditions>
+                                      <conditionGroups>
+                                        <conditionGroup type="or">
+                                          <conditions>
+                                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5341-6e94-fd48-7460" type="equalTo"/>
+                                          </conditions>
+                                        </conditionGroup>
+                                      </conditionGroups>
                                     </conditionGroup>
                                   </conditionGroups>
                                 </conditionGroup>
@@ -785,6 +862,13 @@
                                       <conditions>
                                         <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="6492-fa5a-5a67-6b50" type="equalTo"/>
                                       </conditions>
+                                      <conditionGroups>
+                                        <conditionGroup type="or">
+                                          <conditions>
+                                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5341-6e94-fd48-7460" type="equalTo"/>
+                                          </conditions>
+                                        </conditionGroup>
+                                      </conditionGroups>
                                     </conditionGroup>
                                   </conditionGroups>
                                 </conditionGroup>
@@ -850,6 +934,13 @@
                                   <conditions>
                                     <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="6492-fa5a-5a67-6b50" type="equalTo"/>
                                   </conditions>
+                                  <conditionGroups>
+                                    <conditionGroup type="or">
+                                      <conditions>
+                                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5341-6e94-fd48-7460" type="equalTo"/>
+                                      </conditions>
+                                    </conditionGroup>
+                                  </conditionGroups>
                                 </conditionGroup>
                               </conditionGroups>
                             </conditionGroup>
@@ -894,6 +985,13 @@
                                   <conditions>
                                     <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="6492-fa5a-5a67-6b50" type="equalTo"/>
                                   </conditions>
+                                  <conditionGroups>
+                                    <conditionGroup type="or">
+                                      <conditions>
+                                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5341-6e94-fd48-7460" type="equalTo"/>
+                                      </conditions>
+                                    </conditionGroup>
+                                  </conditionGroups>
                                 </conditionGroup>
                               </conditionGroups>
                             </conditionGroup>
@@ -952,6 +1050,13 @@
                               <conditions>
                                 <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="6492-fa5a-5a67-6b50" type="equalTo"/>
                               </conditions>
+                              <conditionGroups>
+                                <conditionGroup type="or">
+                                  <conditions>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5341-6e94-fd48-7460" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
                             </conditionGroup>
                           </conditionGroups>
                         </conditionGroup>
@@ -989,6 +1094,13 @@
                               <conditions>
                                 <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="6492-fa5a-5a67-6b50" type="equalTo"/>
                               </conditions>
+                              <conditionGroups>
+                                <conditionGroup type="or">
+                                  <conditions>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5341-6e94-fd48-7460" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
                             </conditionGroup>
                           </conditionGroups>
                         </conditionGroup>
@@ -1050,6 +1162,13 @@
                                   <conditions>
                                     <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="6492-fa5a-5a67-6b50" type="equalTo"/>
                                   </conditions>
+                                  <conditionGroups>
+                                    <conditionGroup type="or">
+                                      <conditions>
+                                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5341-6e94-fd48-7460" type="equalTo"/>
+                                      </conditions>
+                                    </conditionGroup>
+                                  </conditionGroups>
                                 </conditionGroup>
                               </conditionGroups>
                             </conditionGroup>
@@ -1094,6 +1213,13 @@
                                   <conditions>
                                     <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="6492-fa5a-5a67-6b50" type="equalTo"/>
                                   </conditions>
+                                  <conditionGroups>
+                                    <conditionGroup type="or">
+                                      <conditions>
+                                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5341-6e94-fd48-7460" type="equalTo"/>
+                                      </conditions>
+                                    </conditionGroup>
+                                  </conditionGroups>
                                 </conditionGroup>
                               </conditionGroups>
                             </conditionGroup>
@@ -1144,6 +1270,13 @@
                           <conditions>
                             <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="aa67-eb60-9e79-897c" type="equalTo"/>
                           </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5341-6e94-fd48-7460" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
                         </conditionGroup>
                       </conditionGroups>
                     </conditionGroup>
@@ -1169,6 +1302,13 @@
                       <conditions>
                         <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="b9a7-a628-d572-6b39" type="equalTo"/>
                       </conditions>
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5341-6e94-fd48-7460" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
                     </conditionGroup>
                   </conditionGroups>
                 </conditionGroup>
@@ -1256,6 +1396,13 @@
                           <conditions>
                             <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="b9a7-a628-d572-6b39" type="equalTo"/>
                           </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5341-6e94-fd48-7460" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
                         </conditionGroup>
                       </conditionGroups>
                     </conditionGroup>
@@ -1286,6 +1433,13 @@
                           <conditions>
                             <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="b9a7-a628-d572-6b39" type="equalTo"/>
                           </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5341-6e94-fd48-7460" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
                         </conditionGroup>
                       </conditionGroups>
                     </conditionGroup>
@@ -1330,6 +1484,13 @@
                       <conditions>
                         <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="b9a7-a628-d572-6b39" type="equalTo"/>
                       </conditions>
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5341-6e94-fd48-7460" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
                     </conditionGroup>
                   </conditionGroups>
                 </conditionGroup>
@@ -1353,6 +1514,13 @@
                       <conditions>
                         <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="b9a7-a628-d572-6b39" type="equalTo"/>
                       </conditions>
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5341-6e94-fd48-7460" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
                     </conditionGroup>
                   </conditionGroups>
                 </conditionGroup>
@@ -1400,6 +1568,13 @@
                           <conditions>
                             <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="b9a7-a628-d572-6b39" type="equalTo"/>
                           </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5341-6e94-fd48-7460" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
                         </conditionGroup>
                       </conditionGroups>
                     </conditionGroup>
@@ -1430,6 +1605,13 @@
                           <conditions>
                             <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="b9a7-a628-d572-6b39" type="equalTo"/>
                           </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5341-6e94-fd48-7460" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
                         </conditionGroup>
                       </conditionGroups>
                     </conditionGroup>
@@ -1476,6 +1658,13 @@
                           <conditions>
                             <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="6492-fa5a-5a67-6b50" type="equalTo"/>
                           </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5341-6e94-fd48-7460" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
                         </conditionGroup>
                       </conditionGroups>
                     </conditionGroup>
@@ -1504,6 +1693,13 @@
                               <conditions>
                                 <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="11f1-5b6d-9023-2804" type="equalTo"/>
                               </conditions>
+                              <conditionGroups>
+                                <conditionGroup type="or">
+                                  <conditions>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5341-6e94-fd48-7460" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
                             </conditionGroup>
                           </conditionGroups>
                         </conditionGroup>
@@ -1560,6 +1756,13 @@
                               <conditions>
                                 <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="11f1-5b6d-9023-2804" type="equalTo"/>
                               </conditions>
+                              <conditionGroups>
+                                <conditionGroup type="or">
+                                  <conditions>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5341-6e94-fd48-7460" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
                             </conditionGroup>
                           </conditionGroups>
                         </conditionGroup>
@@ -1590,6 +1793,13 @@
                               <conditions>
                                 <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="11f1-5b6d-9023-2804" type="equalTo"/>
                               </conditions>
+                              <conditionGroups>
+                                <conditionGroup type="or">
+                                  <conditions>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5341-6e94-fd48-7460" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
                             </conditionGroup>
                           </conditionGroups>
                         </conditionGroup>
@@ -1804,11 +2014,17 @@
                 </conditionGroup>
               </conditionGroups>
             </modifier>
+            <modifier type="set" field="c18c-eeab-eef5-87b9" value="1.0">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5341-6e94-fd48-7460" type="equalTo"/>
+              </conditions>
+            </modifier>
           </modifiers>
         </modifierGroup>
       </modifierGroups>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="81e6-9c5b-03b3-e7ed" type="max"/>
+        <constraint field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="c18c-eeab-eef5-87b9" type="min"/>
       </constraints>
       <categoryLinks>
         <categoryLink id="4fee-d5b0-4bee-4ba9" name="New CategoryLink" hidden="false" targetId="6e9c-4e8f-3256-f4f0" primary="true"/>
@@ -2076,28 +2292,10 @@
         <categoryLink id="2539-8d90-ce23-594f" name="Rohan" hidden="false" targetId="eb6a-b0c5-c206-9247" primary="false"/>
       </categoryLinks>
     </entryLink>
+    <entryLink id="d513-fbd8-ffde-f963" name="Helm&apos;s Guard" hidden="false" collective="false" import="true" targetId="5341-6e94-fd48-7460" type="selectionEntry"/>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="e89a-8ff1-5fda-04cc" name="Warband" hidden="false" collective="false" import="true" type="upgrade">
-      <modifiers>
-        <modifier type="increment" field="2694-499e-fdaa-0d0c" value="1.0">
-          <repeats>
-            <repeat field="391e-19ac-b71d-f2e3" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="model" repeats="1" roundUp="true"/>
-          </repeats>
-          <conditions>
-            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="aa67-eb60-9e79-897c" type="equalTo"/>
-          </conditions>
-        </modifier>
-        <modifier type="increment" field="2694-499e-fdaa-0d0c" value="1.0">
-          <repeats>
-            <repeat field="selections" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="36c7-7c1e-0fd3-0c44" repeats="1" roundUp="true"/>
-            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="2897-1205-c704-2582" repeats="1" roundUp="true"/>
-          </repeats>
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="aa67-eb60-9e79-897c" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <modifierGroups>
         <modifierGroup>
           <modifiers>
@@ -2135,6 +2333,63 @@
               <conditions>
                 <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5e53-b18f-0f14-dc92" type="instanceOf"/>
               </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+        <modifierGroup>
+          <modifiers>
+            <modifier type="increment" field="2694-499e-fdaa-0d0c" value="1.0">
+              <repeats>
+                <repeat field="391e-19ac-b71d-f2e3" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e89a-8ff1-5fda-04cc" repeats="1" roundUp="true"/>
+              </repeats>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="aa67-eb60-9e79-897c" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="2c98-43f7-7ad1-b2a5" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5341-6e94-fd48-7460" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="increment" field="2694-499e-fdaa-0d0c" value="1.0">
+              <repeats>
+                <repeat field="selections" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="36c7-7c1e-0fd3-0c44" repeats="1" roundUp="true"/>
+                <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="2897-1205-c704-2582" repeats="1" roundUp="true"/>
+              </repeats>
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="aa67-eb60-9e79-897c" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="2c98-43f7-7ad1-b2a5" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5341-6e94-fd48-7460" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
             </modifier>
           </modifiers>
         </modifierGroup>
@@ -2989,6 +3244,13 @@
                                           <conditions>
                                             <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="11f1-5b6d-9023-2804" type="equalTo"/>
                                           </conditions>
+                                          <conditionGroups>
+                                            <conditionGroup type="or">
+                                              <conditions>
+                                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5341-6e94-fd48-7460" type="equalTo"/>
+                                              </conditions>
+                                            </conditionGroup>
+                                          </conditionGroups>
                                         </conditionGroup>
                                       </conditionGroups>
                                     </conditionGroup>
@@ -3378,7 +3640,7 @@
             </infoGroup>
           </infoGroups>
           <selectionEntries>
-            <selectionEntry id="b020-b035-3ef9-35eb" name="Warrior" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="b020-b035-3ef9-35eb" name="Warrior" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="c4d2-dff6-03ed-5003" type="min"/>
                 <constraint field="selections" scope="parent" value="15.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="7cb8-8588-92ed-eb65" type="max"/>
@@ -3425,6 +3687,13 @@
                           <conditions>
                             <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="6492-fa5a-5a67-6b50" type="equalTo"/>
                           </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5341-6e94-fd48-7460" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
                         </conditionGroup>
                       </conditionGroups>
                     </conditionGroup>
@@ -3448,6 +3717,13 @@
                           <conditions>
                             <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="6492-fa5a-5a67-6b50" type="equalTo"/>
                           </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5341-6e94-fd48-7460" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
                         </conditionGroup>
                       </conditionGroups>
                     </conditionGroup>

--- a/Survivors_of_Lake-town.cat
+++ b/Survivors_of_Lake-town.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="c0f3-7a3d-ea88-3fea" name="Survivors of Lake-town" revision="4" battleScribeVersion="2.03" library="false" gameSystemId="3e16-9abf-6238-4ed9" gameSystemRevision="39" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="c0f3-7a3d-ea88-3fea" name="Survivors of Lake-town" revision="5" battleScribeVersion="2.03" library="false" gameSystemId="3e16-9abf-6238-4ed9" gameSystemRevision="39" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="c0f3-7a3d-pubN65612" name="Armies of the Hobbit"/>
   </publications>
@@ -473,28 +473,9 @@
           </selectionEntries>
           <selectionEntryGroups>
             <selectionEntryGroup id="f2a6-127e-3572-c65a" name="Wargear" hidden="false" collective="false" import="true">
-              <selectionEntryGroups>
-                <selectionEntryGroup id="2432-0c40-2e14-d17f" name=" " hidden="false" collective="false" import="true" defaultSelectionEntryId="eceb-f773-9a30-a582">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f202-b8f6-0203-857d" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98a5-0e37-f455-4bcd" type="max"/>
-                  </constraints>
-                  <entryLinks>
-                    <entryLink id="eceb-f773-9a30-a582" name="Sword" hidden="false" collective="false" import="true" targetId="64a3-2e98-a578-1a2d" type="selectionEntry">
-                      <modifiers>
-                        <modifier type="set" field="26be-b7ba-4fb0-04dc" value="0.0"/>
-                      </modifiers>
-                    </entryLink>
-                    <entryLink id="e8fc-7809-1d91-035d" name="Axe" hidden="false" collective="false" import="true" targetId="6487-f2cf-5eb7-a780" type="selectionEntry">
-                      <modifiers>
-                        <modifier type="set" field="10cf-3df6-657b-ff0f" value="0.0"/>
-                      </modifiers>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
               <entryLinks>
                 <entryLink id="1efe-42ab-8a30-9d2e" name="Armour" hidden="false" collective="false" import="true" targetId="991c-46d3-d618-c49e" type="selectionEntry"/>
+                <entryLink id="7031-4879-6ef5-7009" name="Weapon" hidden="false" collective="false" import="true" targetId="2fb2-bc75-1f44-5626" type="selectionEntryGroup"/>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="6eec-d140-a1fb-97e2" name="Options" hidden="false" collective="false" import="true">
@@ -578,14 +559,18 @@
         <entryLink id="35e0-1b52-af8d-b256" name="Sigrid &amp; Tilda" hidden="true" collective="false" import="true" targetId="3847-63c0-b826-d5df" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="false">
-              <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ab5e-daa4-a57b-e5ed" type="instanceOf"/>
-              </conditions>
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
                     <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9a57-ffe5-384e-03be" type="instanceOf"/>
                   </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ab5e-daa4-a57b-e5ed" type="instanceOf"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
                 </conditionGroup>
               </conditionGroups>
             </modifier>

--- a/The_White_Council.cat
+++ b/The_White_Council.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="f6b7-f518-07fb-42c8" name="The White Council" revision="3" battleScribeVersion="2.03" authorName="Hukoseft" authorContact="hukoseft@gmail.com" library="false" gameSystemId="3e16-9abf-6238-4ed9" gameSystemRevision="39" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="f6b7-f518-07fb-42c8" name="The White Council" revision="4" battleScribeVersion="2.03" authorName="Hukoseft" authorContact="hukoseft@gmail.com" library="false" gameSystemId="3e16-9abf-6238-4ed9" gameSystemRevision="39" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <selectionEntries>
     <selectionEntry id="dfe0-8c2b-82ea-0cd6" name="Elrond, Master of Rivendell" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
@@ -54,7 +54,7 @@
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9b19-40ce-c34c-e2a2" type="max"/>
       </constraints>
       <categoryLinks>
-        <categoryLink id="efbd-f8ce-d103-3805" name="New CategoryLink" hidden="false" targetId="6e9c-4e8f-3256-f4f0" primary="true"/>
+        <categoryLink id="a6f0-c53a-df5c-9b7a" name="New CategoryLink" hidden="false" targetId="5daa-6832-f49b-2b35" primary="true"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="6e41-f5b6-ed3b-ef0a" name="Galadriel, Lady of Light" hidden="false" collective="false" import="true" targetId="b501-ff8f-b343-8801" type="selectionEntry"/>


### PR DESCRIPTION
•	Isengard
o	Fixed bug where Sharku cant have more than 12 warriors in warband in LL Wolves of Isengard
o	Fixed bug where Thrydan cant have more than 12 warriors in warband in LL Army of Dunland
•	Rivendell
o	Fixed bug where neither Lindir nor Glorfindel have a heroic tier assigned
o	Defence value for Warriors not being correct.
o	Fixed issue which caused Glorfindel to have a warband size of 15.
•	Survivors of Lake-Town
o	Fixed issue with Sigrid & Tilda not appearing as options for Bard/Bain’s warbands
o	Lake-town Militia default weapon choice should be 1 of the weapons rather than both.
•	Numenor
o	Increase the courage on profile when army bonus is in the list.
•	Rohan
o	Added Helm’s Guard LL to the force options
o	Fixed issue to bow limits in Helm’s Guard and Defenders of Helm’s deep LLs
•	Halls of Thranduil
o	Added missing Elven Cloak to Tauriel’s wargear.
•	The White Council
o	Fixed Galadriel, Lady of Light’s heroic tier