### PR TITLE
Issue 263

### DIFF
--- a/The_Dead_of_Dunharrow.cat
+++ b/The_Dead_of_Dunharrow.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="58ee-b7a3-bb66-6a94" name="The Dead of Dunharrow" revision="17" battleScribeVersion="2.03" authorName="Hukoseft" authorContact="hukoseft@gmail.com" library="false" gameSystemId="3e16-9abf-6238-4ed9" gameSystemRevision="99" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="58ee-b7a3-bb66-6a94" name="The Dead of Dunharrow" revision="18" battleScribeVersion="2.03" authorName="Hukoseft" authorContact="hukoseft@gmail.com" library="false" gameSystemId="3e16-9abf-6238-4ed9" gameSystemRevision="108" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="58ee-b7a3-pubN65807" name="Armies of Lord of the Rings"/>
     <publication id="58ee-b7a3-pubN66328" name="Gondor at War"/>
@@ -372,14 +372,14 @@
                 <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="5daa-6832-f49b-2b35" type="instanceOf"/>
               </conditions>
             </modifier>
-            <modifier type="set" field="9016-e4c2-0744-d909" value="8.0">
+            <modifier type="set" field="033a-53da-2041-773a" value="8.0">
               <conditions>
                 <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="524a-3314-7561-9d99" type="instanceOf"/>
               </conditions>
             </modifier>
-            <modifier type="increment" field="9016-e4c2-0744-d909" value="1.0">
+            <modifier type="increment" field="5be0-2462-d970-0498" value="1.0">
               <repeats>
-                <repeat field="391e-19ac-b71d-f2e3" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="f44d-6fb5-463a-a6e7" repeats="1" roundUp="true"/>
+                <repeat field="391e-19ac-b71d-f2e3" scope="force" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="750b-5ea7-f0f8-bba3" repeats="1" roundUp="true"/>
               </repeats>
             </modifier>
           </modifiers>
@@ -389,7 +389,8 @@
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2d30-e9f2-cda4-1e13" type="max"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4319-201d-3e4c-0a7e" type="min"/>
         <constraint field="391e-19ac-b71d-f2e3" scope="parent" value="18.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e1b-a1ac-9027-c318" type="max"/>
-        <constraint field="391e-19ac-b71d-f2e3" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="9016-e4c2-0744-d909" type="min"/>
+        <constraint field="391e-19ac-b71d-f2e3" scope="parent" value="-1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="033a-53da-2041-773a" type="min"/>
+        <constraint field="ab3b-a62b-ef54-533c" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5be0-2462-d970-0498" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="4498-1d8f-42d7-21da" name="Warrior of the Dead" hidden="false" collective="false" import="true" type="upgrade">
@@ -544,7 +545,7 @@
                 <characteristic name="Movement" typeId="b547-99cc-2ac6-2a69">6&quot;</characteristic>
                 <characteristic name="Fight" typeId="7b7e-d26d-b685-545a">3/4+</characteristic>
                 <characteristic name="Strength" typeId="241d-1a6f-8463-5f1c">3</characteristic>
-                <characteristic name="Defense" typeId="d64a-e776-38fd-3019">7</characteristic>
+                <characteristic name="Defense" typeId="d64a-e776-38fd-3019">8</characteristic>
                 <characteristic name="Attack" typeId="6235-3861-befd-7242">1</characteristic>
                 <characteristic name="Wounds" typeId="ae83-f720-58f2-1a6d">1</characteristic>
                 <characteristic name="Courage" typeId="a0e1-d7a9-598e-1545">6</characteristic>


### PR DESCRIPTION
Corrected Rider of the Dead's Defence value from 7 to 8 per issue 263.

Fixed two warband conditions that wouldn't allow saving the file.

(Leaderless warbands require 8 warriors for The Dead of Dunharrow and the 1/3 generic bow condition)